### PR TITLE
Add priority_id to required fields. Redirect to tickets.show instead of ...

### DIFF
--- a/app/controllers/TicketsController.php
+++ b/app/controllers/TicketsController.php
@@ -237,7 +237,7 @@ class TicketsController extends \BaseController {
 			$ticket->replies = $ticket->replies +1;
 			$ticket->save();
 
-			return Redirect::route('tickets.show', $id)->with('message', [
+			return Redirect::route('tickets.index')->with('message', [
 				'class' => 'success',
 				'message' => 'Ticket Replied To.'
 			]);

--- a/app/controllers/TicketsController.php
+++ b/app/controllers/TicketsController.php
@@ -212,6 +212,7 @@ class TicketsController extends \BaseController {
 
 		$rules = array(
 			'status_id' => 'required',
+			'priority_id' => 'required',
 			'content' => 'required'
 		);
 
@@ -236,7 +237,7 @@ class TicketsController extends \BaseController {
 			$ticket->replies = $ticket->replies +1;
 			$ticket->save();
 
-			return Redirect::route('tickets.index')->with('flash', [
+			return Redirect::route('tickets.show', $id)->with('message', [
 				'class' => 'success',
 				'message' => 'Ticket Replied To.'
 			]);


### PR DESCRIPTION
While poking around at the ticket reply functionality it seemed odd to me to post a reply and get redirected to the tickets.index route. I'm open to discussion if redirecting to tickets.show (as in this PR) is better / worse / doesn't matter.